### PR TITLE
update all references to old project name to keycloak-client-golang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := user-management-api
+PROJECT := keycloak-client-golang
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
 
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_new-logo_horizontal_rgb_small.png)
 
-[![GitHub releases](https://img.shields.io/github/release/greenbone/user-management-api.svg)](https://github.com/greenbone/user-management-api/releases)
+[![GitHub releases](https://img.shields.io/github/release/greenbone/keycloak-client-golang.svg)](https://github.com/greenbone/keycloak-client-golang/releases)
 
 # User management modules
 
@@ -11,7 +11,7 @@ This repository contains reusable user management modules.
 See [auth/example_test.go](auth/example_test.go) for example usage or snippet below:
 
 ```go
-import "github.com/greenbone/user-management-api/auth"
+import "github.com/greenbone/keycloak-client-golang/auth"
 
 func main() {
     realmInfo := auth.KeycloakRealmInfo{
@@ -75,9 +75,9 @@ This project is maintained by [Greenbone AG][Greenbone Networks]
 ## Contributing
 
 Your contributions are highly appreciated. Please
-[create a pull request](https://github.com/greenbone/user-management-api/pulls)
+[create a pull request](https://github.com/greenbone/keycloak-client-golang/pulls)
 on GitHub. Bigger changes need to be discussed with the development team via the
-[issues section at GitHub](https://github.com/greenbone/user-management-api/issues)
+[issues section at GitHub](https://github.com/greenbone/keycloak-client-golang/issues)
 first.
 
 ## License

--- a/auth/example_test.go
+++ b/auth/example_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/samber/lo"
 
-	"github.com/greenbone/user-management-api/auth"
+	"github.com/greenbone/keycloak-client-golang/auth"
 )
 
 func setupToken() (token string, clean func()) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/greenbone/user-management-api
+module github.com/greenbone/keycloak-client-golang
 
 go 1.21
 


### PR DESCRIPTION
## What

Rename project from user-management-api to keycloak-client-golang


## References

AT-1043


