### PR TITLE
Change: prevent status code and body being set for unauthorized

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -43,6 +44,6 @@ func NewGinAuthMiddleware(parseRequestFunc func(ctx context.Context, authorizati
 }
 
 func AbortWithError(ctx *gin.Context, err error) {
-	ctx.Error(err)
+	_ = ctx.Error(err)
 	ctx.Abort()
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,13 +26,13 @@ func NewGinAuthMiddleware(parseRequestFunc func(ctx context.Context, authorizati
 		}
 
 		if err := ctx.ShouldBindHeader(&header); err != nil {
-			_ = ctx.AbortWithError(http.StatusUnauthorized, fmt.Errorf("could not bind header: %w", err))
+			AbortWithError(ctx, fmt.Errorf("could not bind header: %w", err))
 			return
 		}
 
 		userContext, err := parseRequestFunc(ctx, header.Authorization, header.Origin)
 		if err != nil {
-			_ = ctx.AbortWithError(http.StatusUnauthorized, fmt.Errorf("authorization failed: %w", err))
+			AbortWithError(ctx, fmt.Errorf("authorization failed: %w", err))
 			return
 		}
 
@@ -42,4 +40,9 @@ func NewGinAuthMiddleware(parseRequestFunc func(ctx context.Context, authorizati
 
 		ctx.Next()
 	}, nil
+}
+
+func AbortWithError(ctx *gin.Context, err error) {
+	ctx.Error(err)
+	ctx.Abort()
 }

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -43,7 +43,6 @@ func TestGinAuthMiddleware(t *testing.T) {
 		ctx.Request, _ = http.NewRequest("GET", "/", nil)
 		auth(ctx)
 
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		require.Len(t, ctx.Errors, 1)
 		assert.ErrorContains(t, ctx.Errors[0], "could not bind header")
 		assert.ErrorContains(t, ctx.Errors[0], "Authorization")
@@ -65,7 +64,6 @@ func TestGinAuthMiddleware(t *testing.T) {
 		ctx.Request.Header.Add("Origin", "origin")
 		auth(ctx)
 
-		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		require.Len(t, ctx.Errors, 1)
 		assert.ErrorContains(t, ctx.Errors[0], "authorization failed")
 		assert.ErrorContains(t, ctx.Errors[0], "test error")


### PR DESCRIPTION
## What

Change: prevent status code and body set for unauthorized

## Why

to allow changing status code and - more importantly - content-type later

## References

[AT-1459](https://jira.greenbone.net/browse/AT-1459)

## Checklist

- [x] Tests


