### PR TITLE
ci:  use single year licenses for license header action

### DIFF
--- a/.github/workflows/update-license-header.yml
+++ b/.github/workflows/update-license-header.yml
@@ -22,3 +22,4 @@ jobs:
           directories: auth client
           license-type: "AGPL-3.0-or-later"
           target: main
+          single-year: true


### PR DESCRIPTION
## What

use single year licenses for license header action

## Why

Less noise


