### PR TITLE
change: refine jwt handling (breaking change)

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,22 +9,29 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/Nerzal/gocloak/v13"
+	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 	"github.com/golang-jwt/jwt/v5"
 )
 
 // KeycloakAuthorizer is used to validate if JWT has a correct signature and is valid and returns keycloak claims
 type KeycloakAuthorizer struct {
-	realmInfo KeycloakRealmInfo
-	client    *gocloak.GoCloak
+	realmInfo        KeycloakRealmInfo
+	client           *gocloak.GoCloak
+	validator        *jwt.Validator
+	validatorOptions []jwt.ParserOption
+	validMethods     []string
 }
 
 // KeycloakRealmInfo provides keycloak realm and server information
 type KeycloakRealmInfo struct {
 	RealmId               string // RealmId is the realm name that is passed to services via env vars
 	AuthServerInternalUrl string // AuthServerInternalUrl should point to keycloak auth server on internal (not public) network, e.g. http://keycloak:8080/auth; used for contacting keycloak for realm certificate for JWT
+	AuthServerPublicUrl   string // AuthServerPublicUrl should point to keycloak auth server on public network; used for validating issuer claim in JWT
 }
 
 func (i *KeycloakRealmInfo) validate() error {
@@ -37,6 +44,11 @@ func (i *KeycloakRealmInfo) validate() error {
 	_, err := url.ParseRequestURI(i.AuthServerInternalUrl)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("couldn't parse auth server internal url: %w", err))
+	}
+
+	_, err = url.ParseRequestURI(i.AuthServerPublicUrl)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("couldn't parse auth server public url: %w", err))
 	}
 
 	if len(errs) > 0 {
@@ -64,12 +76,43 @@ func NewKeycloakAuthorizer(realmInfo KeycloakRealmInfo, options ...func(*Keycloa
 		o(authorizer)
 	}
 
+	authorizer.validatorOptions = append(authorizer.validatorOptions,
+		jwt.WithIssuer(fmt.Sprintf("%s/realms/%s", realmInfo.AuthServerPublicUrl, realmInfo.RealmId)),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuedAt(),
+	)
+	authorizer.validator = jwt.NewValidator(authorizer.validatorOptions...)
+
 	return authorizer, nil
 }
 
 func ConfigureGoCloak(f func(c *gocloak.GoCloak)) func(a *KeycloakAuthorizer) {
 	return func(a *KeycloakAuthorizer) {
 		f(a.client)
+	}
+}
+
+// WithValidMethods sets the allowed signing methods for the JWT parser.
+// Empty list means all signing methods permitted by gocloak are allowed.
+func WithValidMethods(methods ...string) func(a *KeycloakAuthorizer) {
+	return func(a *KeycloakAuthorizer) {
+		a.validMethods = methods
+	}
+}
+
+// WithLeeway sets the leeway window for the JWT parser.
+// This is used to account for clock skew when validating the token's claims.
+func WithLeeway(leeway time.Duration) func(a *KeycloakAuthorizer) {
+	return func(a *KeycloakAuthorizer) {
+		a.validatorOptions = append(a.validatorOptions, jwt.WithLeeway(leeway))
+	}
+}
+
+// WithAudience configures the validator to require any of the specified audiences in the `aud` claim.
+// Validation will fail if the audience is not listed in the token or the `aud` claim is missing.
+func WithAudience(audience ...string) func(a *KeycloakAuthorizer) {
+	return func(a *KeycloakAuthorizer) {
+		a.validatorOptions = append(a.validatorOptions, jwt.WithAudience(audience...))
 	}
 }
 
@@ -131,7 +174,6 @@ func (a *KeycloakAuthorizer) ParseAuthorizationHeader(ctx context.Context, authH
 func (a *KeycloakAuthorizer) ParseJWT(ctx context.Context, token string) (UserContext, error) {
 	type customClaims struct {
 		jwt.RegisteredClaims
-		UserId         string   `json:"sub"`
 		Email          string   `json:"email"`
 		UserName       string   `json:"preferred_username"`
 		Roles          []string `json:"roles"`
@@ -139,19 +181,40 @@ func (a *KeycloakAuthorizer) ParseJWT(ctx context.Context, token string) (UserCo
 		AllowedOrigins []string `json:"allowed-origins"`
 	}
 
-	jwtToken, _, err := jwt.NewParser().ParseUnverified(token, &customClaims{})
+	tokenHeader, err := jwx.DecodeAccessTokenHeader(token)
+	if err != nil {
+		return UserContext{}, fmt.Errorf("could not decode token header: %w", err)
+	}
+	if len(a.validMethods) > 0 {
+		if !slices.Contains(a.validMethods, tokenHeader.Alg) {
+			return UserContext{}, fmt.Errorf("invalid token signing method: %s", tokenHeader.Alg)
+		}
+	}
+
+	// verify token signature
+	if _, _, err := a.client.DecodeAccessToken(ctx, token, a.realmInfo.RealmId); err != nil {
+		return UserContext{}, fmt.Errorf("validation of token failed: %w", err)
+	}
+
+	// extract claims from token; signature is validated above; claims are validated below
+	jwtToken, _, err := jwt.NewParser(jwt.WithoutClaimsValidation()).ParseUnverified(token, &customClaims{})
 	if err != nil {
 		return UserContext{}, fmt.Errorf("parsing of token failed: %w", err)
 	}
 	claims := jwtToken.Claims.(*customClaims)
 
-	if _, _, err := a.client.DecodeAccessToken(ctx, token, a.realmInfo.RealmId); err != nil {
-		return UserContext{}, fmt.Errorf("validation of token failed: %w", err)
+	// verify claims
+	err = a.validator.Validate(claims)
+	if err != nil {
+		return UserContext{}, fmt.Errorf("validation of token claims failed: %w", err)
+	}
+	if claims.Subject == "" { // [jwt.Validator] does not support just checking for non-empty subject claim, so we check it here
+		return UserContext{}, fmt.Errorf("validation of token claims failed: missing subject claim")
 	}
 
 	return UserContext{
 		Realm:          a.realmInfo.RealmId,
-		UserID:         claims.UserId,
+		UserID:         claims.Subject,
 		UserName:       claims.UserName,
 		EmailAddress:   claims.Email,
 		Roles:          claims.Roles,

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13"
-	"github.com/Nerzal/gocloak/v13/pkg/jwx"
+	"github.com/Nerzal/gocloak/v14"
+	"github.com/Nerzal/gocloak/v14/pkg/jwx"
 	"github.com/golang-jwt/jwt/v5"
 )
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,14 +33,26 @@ func TestNewKeycloakAuthorizer(t *testing.T) {
 		}
 		t.Run("internal", func(t *testing.T) {
 			for _, test := range tests {
-				t.Run(test, func(t *testing.T) {
+				t.Run("internal url "+test, func(t *testing.T) {
 					authorizer, err := NewKeycloakAuthorizer(KeycloakRealmInfo{
 						AuthServerInternalUrl: test,
 						RealmId:               validRealm,
+						AuthServerPublicUrl:   validPublicUrl,
 					})
 
 					assert.ErrorContains(t, err, "invalid realm info")
 					assert.ErrorContains(t, err, "couldn't parse auth server internal url")
+					assert.Nil(t, authorizer)
+				})
+				t.Run("public url "+test, func(t *testing.T) {
+					authorizer, err := NewKeycloakAuthorizer(KeycloakRealmInfo{
+						AuthServerPublicUrl:   test,
+						RealmId:               validRealm,
+						AuthServerInternalUrl: validInternalUrl,
+					})
+
+					assert.ErrorContains(t, err, "invalid realm info")
+					assert.ErrorContains(t, err, "couldn't parse auth server public url")
 					assert.Nil(t, authorizer)
 				})
 			}
@@ -50,6 +63,7 @@ func TestNewKeycloakAuthorizer(t *testing.T) {
 		authorizer, err := NewKeycloakAuthorizer(KeycloakRealmInfo{
 			RealmId:               validRealm,
 			AuthServerInternalUrl: validInternalUrl,
+			AuthServerPublicUrl:   validPublicUrl,
 		})
 
 		assert.NoError(t, err)
@@ -58,25 +72,37 @@ func TestNewKeycloakAuthorizer(t *testing.T) {
 }
 
 func TestParseJWT(t *testing.T) {
+	tokenIssuer, err := NewTokenIssuer(publicKeyALG, publicKeyID)
+	require.NoError(t, err)
+	authServer := FakeAuthServer(t, tokenIssuer)
+
 	authorizer, err := NewKeycloakAuthorizer(KeycloakRealmInfo{
 		RealmId:               validRealm,
-		AuthServerInternalUrl: validInternalUrl,
-	})
+		AuthServerInternalUrl: authServer.URL,
+		AuthServerPublicUrl:   validPublicUrl,
+	},
+		WithValidMethods("RS256"),
+		WithAudience(validAudience, "other valid audience"),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, authorizer)
 
-	FakeCertResponse(t, authorizer)
-
 	t.Run("Wrong algorithm", func(t *testing.T) {
-		userContext, err := authorizer.ParseJWT(context.Background(), invalidAlgorithmToken)
+		token := tokenIssuer.GetTokenWithAlg(t, jwt.SigningMethodHS256.Alg(), validClaims())
 
-		assert.ErrorContains(t, err, "validation of token failed")
-		assert.ErrorContains(t, err, "cannot find a key to decode the token")
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "invalid token signing method")
 		assert.Zero(t, userContext)
 	})
 
 	t.Run("Wrong signature", func(t *testing.T) {
-		userContext, err := authorizer.ParseJWT(context.Background(), invalidSignatureToken)
+		token := tokenIssuer.GetToken(t, jwt.MapClaims{
+			"iss": validPublicUrl + "/realms/" + validRealm,
+		})
+		token += "XX" // malformed signature
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
 
 		assert.ErrorContains(t, err, "validation of token failed")
 		assert.ErrorContains(t, err, "crypto/rsa: verification error")
@@ -84,15 +110,85 @@ func TestParseJWT(t *testing.T) {
 	})
 
 	t.Run("Expired token", func(t *testing.T) {
-		userContext, err := authorizer.ParseJWT(context.Background(), expiredToken)
+		claims := validClaims()
+		claims["exp"] = 1500000000
+		token := tokenIssuer.GetToken(t, claims)
 
-		assert.ErrorContains(t, err, "validation of token failed")
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "token has invalid claims")
 		assert.ErrorContains(t, err, "token is expired")
 		assert.Zero(t, userContext)
 	})
 
+	t.Run("missing expiration", func(t *testing.T) {
+		claims := validClaims()
+		delete(claims, "exp")
+		token := tokenIssuer.GetToken(t, claims)
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "validation of token claims failed")
+		assert.ErrorContains(t, err, "exp claim is required")
+		assert.Zero(t, userContext)
+	})
+
+	t.Run("invalid issuedAt", func(t *testing.T) {
+		claims := validClaims()
+		claims["iat"] = 9999999999
+		token := tokenIssuer.GetToken(t, claims)
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "validation of token claims failed")
+		assert.ErrorContains(t, err, "token used before issued")
+		assert.Zero(t, userContext)
+	})
+
+	t.Run("Wrong issuer", func(t *testing.T) {
+		claims := validClaims()
+		claims["iss"] = "invalid_issuer"
+		token := tokenIssuer.GetToken(t, claims)
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "validation of token claims failed")
+		assert.ErrorContains(t, err, "token has invalid issuer")
+		assert.Zero(t, userContext)
+	})
+
+	t.Run("Missing subject", func(t *testing.T) {
+		claims := validClaims()
+		delete(claims, "sub")
+		token := tokenIssuer.GetToken(t, claims)
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "validation of token claims failed")
+		assert.ErrorContains(t, err, "missing subject claim")
+		assert.Zero(t, userContext)
+	})
+
+	t.Run("Wrong audience", func(t *testing.T) {
+		claims := validClaims()
+		claims["aud"] = "invalid_audience"
+		token := tokenIssuer.GetToken(t, claims)
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
+
+		assert.ErrorContains(t, err, "validation of token claims failed")
+		assert.ErrorContains(t, err, "token has invalid audience")
+		assert.Zero(t, userContext)
+	})
+
 	t.Run("Invalid claims", func(t *testing.T) {
-		userContext, err := authorizer.ParseJWT(context.Background(), invalidClaimsToken)
+		claims := validClaims()
+		claims["email"] = 12345
+		claims["roles"] = 1
+		claims["groups"] = 2
+		token := tokenIssuer.GetToken(t, claims)
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
 
 		assert.ErrorContains(t, err, "parsing of token failed")
 		assert.ErrorContains(t, err, "cannot unmarshal number")
@@ -100,7 +196,9 @@ func TestParseJWT(t *testing.T) {
 	})
 
 	t.Run("OK", func(t *testing.T) {
-		userContext, err := authorizer.ParseJWT(context.Background(), validToken)
+		token := tokenIssuer.GetToken(t, validClaims())
+
+		userContext, err := authorizer.ParseJWT(context.Background(), token)
 
 		require.NoError(t, err)
 		require.NotZero(t, userContext)
@@ -111,18 +209,23 @@ func TestParseJWT(t *testing.T) {
 		assert.Equal(t, "initial", userContext.UserName)
 		assert.ElementsMatch(t, []string{"offline_access", "uma_authorization", "user", "default-roles-user-management"}, userContext.Roles)
 		assert.ElementsMatch(t, []string{"user-management-initial"}, userContext.Groups)
+		assert.ElementsMatch(t, []string{validOrigin}, userContext.AllowedOrigins)
 	})
 }
 
 func TestParseAuthorizationHeader(t *testing.T) {
+	tokenIssuer, err := NewTokenIssuer(publicKeyALG, publicKeyID)
+	require.NoError(t, err)
+	authServer := FakeAuthServer(t, tokenIssuer)
+	validToken := tokenIssuer.GetToken(t, validClaims())
+
 	authorizer, err := NewKeycloakAuthorizer(KeycloakRealmInfo{
 		RealmId:               validRealm,
-		AuthServerInternalUrl: validInternalUrl,
+		AuthServerInternalUrl: authServer.URL,
+		AuthServerPublicUrl:   validPublicUrl,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, authorizer)
-
-	FakeCertResponse(t, authorizer)
 
 	t.Run("Invalid fields", func(t *testing.T) {
 		tests := []string{
@@ -148,6 +251,10 @@ func TestParseAuthorizationHeader(t *testing.T) {
 	})
 
 	t.Run("Invalid token", func(t *testing.T) {
+		expiredClaims := validClaims()
+		expiredClaims["exp"] = 1500000000
+		expiredToken := tokenIssuer.GetToken(t, expiredClaims)
+
 		userContext, err := authorizer.ParseAuthorizationHeader(context.Background(), "bearer "+expiredToken)
 
 		assert.ErrorContains(t, err, "validation of token failed")
@@ -169,14 +276,18 @@ func TestParseAuthorizationHeader(t *testing.T) {
 }
 
 func TestParseRequest(t *testing.T) {
+	tokenIssuer, err := NewTokenIssuer(publicKeyALG, publicKeyID)
+	require.NoError(t, err)
+	authServer := FakeAuthServer(t, tokenIssuer)
+	validToken := tokenIssuer.GetToken(t, validClaims())
+
 	authorizer, err := NewKeycloakAuthorizer(KeycloakRealmInfo{
 		RealmId:               validRealm,
-		AuthServerInternalUrl: validInternalUrl,
+		AuthServerInternalUrl: authServer.URL,
+		AuthServerPublicUrl:   validPublicUrl,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, authorizer)
-
-	FakeCertResponse(t, authorizer)
 
 	t.Run("Invalid authorization header", func(t *testing.T) {
 		userContext, err := authorizer.ParseRequest(context.Background(), "invalid", validOrigin)

--- a/auth/example_test.go
+++ b/auth/example_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/big"
@@ -20,13 +21,12 @@ import (
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/jarcoal/httpmock"
 	"github.com/samber/lo"
 
 	"github.com/greenbone/keycloak-client-golang/auth"
 )
 
-func setupToken() (token string, clean func()) {
+func setupToken() (token string, authURL string, clean func()) {
 	privateKey := newPrivateKey()
 
 	validToken := getToken(jwt.MapClaims{
@@ -37,29 +37,31 @@ func setupToken() (token string, clean func()) {
 		"roles":              []string{"offline_access", "uma_authorization", "user", "default-roles-user-management"},
 		"groups":             []string{"user-management-initial"},
 		"allowed-origins":    []string{"http://localhost:3000"},
+		"exp":                1500000000000,
 	}, privateKey)
 
-	cleanUp := mockKeycloak(privateKey.PublicKey)
+	mockKeycloak := mockKeycloak(privateKey.PublicKey, "user-management")
 
-	return validToken, cleanUp
+	return validToken, mockKeycloak.URL, mockKeycloak.Close
 }
 
 func ExampleNewKeycloakAuthorizer() {
-	validToken, clean := setupToken()
+	validToken, authUrl, clean := setupToken()
 	defer clean()
 
 	var (
-		realmId = "user-management"           // keycloak realm name
-		authUrl = "http://keycloak:8080/auth" // keycloak server internal url
-		origin  = "http://localhost:3000"     // request origin, note: it is optional, if request doesn't have Origin header it is not validated
+		realmId       = "user-management" // keycloak realm name
+		authPublicURL = "http://localhost:28080/auth"
+		origin        = "http://localhost:3000" // request origin, note: it is optional, if request doesn't have Origin header it is not validated
 	)
 
 	realmInfo := auth.KeycloakRealmInfo{
 		RealmId:               realmId,
 		AuthServerInternalUrl: authUrl,
+		AuthServerPublicUrl:   authPublicURL,
 	}
 
-	authorizer, err := auth.NewKeycloakAuthorizer(realmInfo, authorizerKeycloakMock) // NOTE: authorizerKeycloakMock only used for mocking keycloak cert response in this example, do not use outside tests!
+	authorizer, err := auth.NewKeycloakAuthorizer(realmInfo)
 	if err != nil {
 		log.Fatal(fmt.Errorf("error creating keycloak token authorizer: %w", err))
 		return
@@ -95,21 +97,22 @@ func ExampleNewKeycloakAuthorizer() {
 }
 
 func ExampleNewGinAuthMiddleware() {
-	validToken, clean := setupToken()
+	validToken, authUrl, clean := setupToken()
 	defer clean()
 
 	var (
-		realmId = "user-management"           // keycloak realm name
-		authUrl = "http://keycloak:8080/auth" // keycloak server internal url
-		origin  = "http://localhost:3000"     // request origin, note: it is optional, if request doesn't have Origin header it is not validated
+		realmId       = "user-management"             // keycloak realm name
+		authPublicURL = "http://localhost:28080/auth" // keycloak server public url
+		origin        = "http://localhost:3000"       // request origin, note: it is optional, if request doesn't have Origin header it is not validated
 	)
 
 	realmInfo := auth.KeycloakRealmInfo{
 		RealmId:               realmId,
 		AuthServerInternalUrl: authUrl,
+		AuthServerPublicUrl:   authPublicURL,
 	}
 
-	authorizer, err := auth.NewKeycloakAuthorizer(realmInfo, authorizerKeycloakMock) // NOTE: authorizerKeycloakMock only used for mocking keycloak cert response in this example, do not use outside tests!
+	authorizer, err := auth.NewKeycloakAuthorizer(realmInfo)
 	if err != nil {
 		log.Fatal(fmt.Errorf("error creating keycloak token authorizer: %w", err))
 		return
@@ -185,9 +188,7 @@ func getBase64N(n *big.Int) string {
 	return res
 }
 
-var authorizerKeycloakMock func(*auth.KeycloakAuthorizer)
-
-func mockKeycloak(publicKey rsa.PublicKey) (clean func()) {
+func mockKeycloak(publicKey rsa.PublicKey, realm string) *httptest.Server {
 	certResponse := &gocloak.CertResponse{
 		Keys: &[]gocloak.CertResponseKey{
 			{
@@ -199,15 +200,15 @@ func mockKeycloak(publicKey rsa.PublicKey) (clean func()) {
 		},
 	}
 
-	certResponder, err := httpmock.NewJsonResponder(200, certResponse)
-	if err != nil {
-		panic(err)
-	}
-	httpmock.RegisterResponder("GET", "http://keycloak:8080/auth/realms/user-management/protocol/openid-connect/certs", certResponder)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != fmt.Sprintf("/realms/%s/protocol/openid-connect/certs", realm) {
+			http.NotFound(w, r)
+			return
+		}
 
-	authorizerKeycloakMock = auth.ConfigureGoCloak(func(c *gocloak.GoCloak) {
-		httpmock.ActivateNonDefault(c.RestyClient().GetClient())
-	})
-
-	return httpmock.DeactivateAndReset
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(certResponse); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
 }

--- a/auth/example_test.go
+++ b/auth/example_test.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/Nerzal/gocloak/v14"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/samber/lo"
@@ -190,7 +190,7 @@ func getBase64N(n *big.Int) string {
 
 func mockKeycloak(publicKey rsa.PublicKey, realm string) *httptest.Server {
 	certResponse := &gocloak.CertResponse{
-		Keys: &[]gocloak.CertResponseKey{
+		Keys: []gocloak.CertResponseKey{
 			{
 				Kid: lo.ToPtr(publicKeyID),
 				Alg: lo.ToPtr(publicKeyALG),

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -10,28 +10,17 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/big"
-	"os"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/jarcoal/httpmock"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	expiredToken          string
-	noRealmToken          string
-	invalidClaimsToken    string
-	invalidIssuerToken    string
-	invalidRealmToken     string
-	invalidAlgorithmToken string
-	invalidSignatureToken string
-	validToken            string
-	publicKey             rsa.PublicKey
 )
 
 const (
@@ -39,81 +28,14 @@ const (
 	validInternalUrl = "http://keycloak:8080/auth"
 	validPublicUrl   = "http://localhost:28080/auth"
 	validOrigin      = "http://localhost:3000"
+	validAudience    = "jwt-tests"
 
 	publicKeyID  = "OMTg5TWEm1TZeqeb2zuJJFX1ZxOwDs_IfPIgJ0uIFU0"
 	publicKeyALG = "RS256"
 )
 
-func init() {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		fmt.Printf("Cannot generate RSA key\n")
-		os.Exit(1)
-	}
-	publicKey = privateKey.PublicKey
-
-	getToken := func(claims jwt.MapClaims) (string, error) {
-		token := jwt.NewWithClaims(jwt.GetSigningMethod(publicKeyALG), claims)
-		token.Header["kid"] = publicKeyID
-
-		return token.SignedString(privateKey) //nolint
-	}
-
-	invalidAlgorithmToken, err = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"iss": validPublicUrl + "/realms/" + validRealm,
-	}).SignedString([]byte("SOME_KEY"))
-	if err != nil {
-		panic(err)
-	}
-
-	expiredToken, err = getToken(jwt.MapClaims{
-		"iss": validPublicUrl + "/realms/" + validRealm,
-		"iat": 1500000000,
-		"exp": 1600000000,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	invalidClaimsToken, err = getToken(jwt.MapClaims{
-		"email":  12345,
-		"roles":  1,
-		"groups": 2,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	invalidIssuerToken, err = getToken(jwt.MapClaims{
-		"iss": "invalid_issuer",
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	invalidRealmToken, err = getToken(jwt.MapClaims{
-		"iss": "http://invalid_url/realms/" + validRealm,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	noRealmToken, err = getToken(jwt.MapClaims{
-		"iss": "",
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	invalidSignatureToken, err = getToken(jwt.MapClaims{
-		"iss": validPublicUrl + "/realms/" + validRealm,
-	})
-	if err != nil {
-		panic(err)
-	}
-	invalidSignatureToken += "XX" // malform signature
-
-	validClaims := jwt.MapClaims{
+func validClaims() jwt.MapClaims {
+	return jwt.MapClaims{
 		"iss":                validPublicUrl + "/realms/" + validRealm,
 		"sub":                "1927ed8a-3f1f-4846-8433-db290ea5ff90",
 		"email":              "initial@host.local",
@@ -121,12 +43,62 @@ func init() {
 		"roles":              []string{"offline_access", "uma_authorization", "user", "default-roles-user-management"},
 		"groups":             []string{"user-management-initial"},
 		"allowed-origins":    []string{validOrigin},
+		"aud":                validAudience,
+		"exp":                9999999999,
+		"iat":                1500000000,
+	}
+}
+
+type TokenIssuer struct {
+	privateKey   *rsa.PrivateKey
+	publicKey    rsa.PublicKey
+	publicKeyALG string
+	publicKeyID  string
+}
+
+func NewTokenIssuer(publicKeyALG, publicKeyID string) (*TokenIssuer, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate RSA key: %w", err)
 	}
 
-	validToken, err = getToken(validClaims)
-	if err != nil {
-		panic(err)
+	return &TokenIssuer{
+		privateKey:   privateKey,
+		publicKey:    privateKey.PublicKey,
+		publicKeyALG: publicKeyALG,
+		publicKeyID:  publicKeyID,
+	}, nil
+}
+
+func (f *TokenIssuer) GetToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	return f.GetTokenWithAlg(t, f.publicKeyALG, claims)
+}
+
+// GetTokenWithAlg creates a JWT token with the given claims and signs it.
+// Note: [alg] currently only supports RS256 and HS256
+func (f *TokenIssuer) GetTokenWithAlg(t *testing.T, alg string, claims jwt.MapClaims) string {
+	t.Helper()
+
+	require.Contains(t, []string{"RS256", "HS256"}, alg, "currently only `alg` `RS256` and `HS256` allowed")
+
+	method := jwt.GetSigningMethod(alg)
+	require.NotNilf(t, method, "unknown signing algorithm: %s", alg)
+
+	token := jwt.NewWithClaims(method, claims)
+	token.Header["kid"] = f.publicKeyID
+
+	var signingKey any
+	signingKey = f.privateKey
+
+	if alg == jwt.SigningMethodHS256.Alg() { // HS256 needs a different key format
+		signingKey = []byte("SOME_KEY")
 	}
+
+	tokenString, err := token.SignedString(signingKey)
+	require.NoError(t, err)
+
+	return tokenString
 }
 
 func getBase64E(e int) string {
@@ -143,24 +115,32 @@ func getBase64N(n *big.Int) string {
 	return res
 }
 
-func FakeCertResponse(t *testing.T, authorizer *KeycloakAuthorizer) {
+func FakeAuthServer(t *testing.T, tokenIssuer *TokenIssuer) *httptest.Server {
 	certResponse := &gocloak.CertResponse{
 		Keys: &[]gocloak.CertResponseKey{
 			{
-				Kid: lo.ToPtr(publicKeyID),
-				Alg: lo.ToPtr(publicKeyALG),
-				N:   lo.ToPtr(getBase64N(publicKey.N)),
-				E:   lo.ToPtr(getBase64E(publicKey.E)),
+				Kid: lo.ToPtr(tokenIssuer.publicKeyID),
+				Alg: lo.ToPtr(tokenIssuer.publicKeyALG),
+				N:   lo.ToPtr(getBase64N(tokenIssuer.publicKey.N)),
+				E:   lo.ToPtr(getBase64E(tokenIssuer.publicKey.E)),
 			},
 		},
 	}
 
-	httpmock.ActivateNonDefault(authorizer.client.RestyClient().GetClient())
-	t.Cleanup(httpmock.DeactivateAndReset)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != fmt.Sprintf("/realms/%s/protocol/openid-connect/certs", validRealm) {
+			http.NotFound(w, r)
+			return
+		}
 
-	certResponder, err := httpmock.NewJsonResponder(200, certResponse)
-	require.NoError(t, err)
-	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", validInternalUrl, validRealm), certResponder)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(certResponse); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server
 }
 
 // Sample of real cert response from keycloak

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -17,7 +17,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/Nerzal/gocloak/v14"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
@@ -117,7 +117,7 @@ func getBase64N(n *big.Int) string {
 
 func FakeAuthServer(t *testing.T, tokenIssuer *TokenIssuer) *httptest.Server {
 	certResponse := &gocloak.CertResponse{
-		Keys: &[]gocloak.CertResponseKey{
+		Keys: []gocloak.CertResponseKey{
 			{
 				Kid: lo.ToPtr(tokenIssuer.publicKeyID),
 				Alg: lo.ToPtr(tokenIssuer.publicKeyALG),

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -70,6 +70,11 @@ func TestGinAuthMiddleware(t *testing.T) {
 	})
 
 	t.Run("OK", func(t *testing.T) {
+		tokenIssuer, err := NewTokenIssuer(publicKeyALG, publicKeyID)
+		require.NoError(t, err)
+
+		token := tokenIssuer.GetToken(t, validClaims())
+
 		parseRequestFunc := func(ctx context.Context, auth string, origin string) (UserContext, error) {
 			return UserContext{
 				Realm:        "user-management",
@@ -88,7 +93,7 @@ func TestGinAuthMiddleware(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(w)
 		ctx.Request, _ = http.NewRequest("GET", "/", nil)
-		ctx.Request.Header.Add("Authorization", fmt.Sprintf("bearer %s", validToken))
+		ctx.Request.Header.Add("Authorization", fmt.Sprintf("bearer %s", token))
 		ctx.Request.Header.Add("Origin", validOrigin)
 		auth(ctx)
 

--- a/client/keycloakJWTReceiverCachedInMemory.go
+++ b/client/keycloakJWTReceiverCachedInMemory.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/Nerzal/gocloak/v14"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/rs/zerolog/log"
 )

--- a/client/keycloakJWTReceiverCachedInMemory_test.go
+++ b/client/keycloakJWTReceiverCachedInMemory_test.go
@@ -7,7 +7,7 @@ package client
 import (
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/Nerzal/gocloak/v14"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/client/keycloakRepository.go
+++ b/client/keycloakRepository.go
@@ -7,7 +7,7 @@ package client
 import (
 	"context"
 
-	"github.com/Nerzal/gocloak/v13"
+	"github.com/Nerzal/gocloak/v14"
 )
 
 type IKeycloakRepository interface {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/greenbone/keycloak-client-golang
 go 1.25.0
 
 require (
-	github.com/Nerzal/gocloak/v13 v13.9.0
+	github.com/Nerzal/gocloak/v14 v14.0.3
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/rs/zerolog v1.35.1
@@ -45,6 +45,7 @@ require (
 	go.mongodb.org/mongo-driver/v2 v2.8.0 // indirect
 	golang.org/x/arch v0.29.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Nerzal/gocloak/v13 v13.9.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/jarcoal/httpmock v1.4.1
 	github.com/rs/zerolog v1.35.1
 	github.com/samber/lo v1.53.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Nerzal/gocloak/v13 v13.9.0 h1:YWsJsdM5b0yhM2Ba3MLydiOlujkBry4TtdzfIzSVZhw=
-github.com/Nerzal/gocloak/v13 v13.9.0/go.mod h1:YYuDcXZ7K2zKECyVP7pPqjKxx2AzYSpKDj8d6GuyM10=
+github.com/Nerzal/gocloak/v14 v14.0.3 h1:qUSkQnTOZoZIjnsXJ3r2NaahhzB49chSLvyAw/JxADU=
+github.com/Nerzal/gocloak/v14 v14.0.3/go.mod h1:USD19a/cfPyP9JskOA6uKKblSD4cJcadRt2ETPpHxlY=
 github.com/bytedance/gopkg v0.1.4 h1:oZnQwnX82KAIWb7033bEwtxvTqXcYMxDBaQxo5JJHWM=
 github.com/bytedance/gopkg v0.1.4/go.mod h1:v1zWfPm21Fb+OsyXN2VAHdL6TBb2L88anLQgdyje6R4=
 github.com/bytedance/sonic v1.15.2 h1:90H+rcF/FwLXwfB1cudOLq/je83n683Utf4Cbp0xHCo=
@@ -102,6 +102,8 @@ golang.org/x/arch v0.29.0 h1:8sSET5wB0+exBm0FGmOtdHMqjlRdV2DRD3/IV6OZgho=
 golang.org/x/arch v0.29.0/go.mod h1:0X+GdSIP+kL5wPmpK7sdkEVTt2XoYP0cSjQSbZBwOi8=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArs
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
-github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.4.0 h1:S6Hrbc7+ywsr0r+RLapfGBHfyefhCTwEh3A0tV913Dw=
@@ -52,8 +50,6 @@ github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy
 github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
-github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## What

Refine JWT handling. Make more claims required and options for valid methods, leeway and audience.

This is a breaking change. Migration: Set new mandatory field `AuthServerPublicUrl` in `KeycloakRealmInfo`

## Why

Better security.

## References

ARTOSI-427

## Checklist

- [x] Tests


